### PR TITLE
Bugfix: Update manifest.json with manifest_version=3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Galaxy Tab",
   "version": "1.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "",
   "chrome_url_overrides": {
     "newtab": "historygraph.html"


### PR DESCRIPTION
Manifest version 2 is deprecated, and support will be removed in 2024. 

See https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline for details.

![image](https://github.com/user-attachments/assets/0d94c444-3ea5-46c5-8663-f7a078e82849)
